### PR TITLE
Dodanie docker-compose.yml

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -8,6 +8,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "PodzielSieKsiazkaConnection": "Server=172.17.0.2,3306;user id=root;password=Inop2020;database=pskdb"
+    "PodzielSieKsiazkaConnection": "Server=db;Database=pskdb;User=root;Password=Inop2020;"
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+version: "3.7"
+
+services:
+  frontend:
+    container_name: frontend
+    restart: unless-stopped
+    tty: true
+    build:
+      context: ../frontend/
+      dockerfile: Dockerfile.prod
+    ports:
+      - "80:80"
+    depends_on:
+      - api
+      - db
+    networks:
+      - app-network
+  db:
+    image: mariadb
+    container_name: mysql
+    restart: unless-stopped
+    tty: true
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_DATABASE: pskdb
+      MYSQL_ROOT_PASSWORD: Inop2020
+      MYSQL_USER: user
+      MYSQL_PASSWORD: Inop2020
+      SERVICE_TAGS: dev
+      SERVICE_NAME: mysql
+    volumes:
+      - dbdata:/var/lib/mysql/
+    networks:
+      - app-network
+  api:
+    container_name: api
+    restart: unless-stopped
+    tty: true
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:80"
+    depends_on:
+      - db
+    networks:
+      - app-network
+networks:
+  app-network:
+    driver: bridge
+volumes:
+  dbdata:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     environment:
       MYSQL_DATABASE: pskdb
       MYSQL_ROOT_PASSWORD: Inop2020
-      MYSQL_USER: user
+      MYSQL_USER: root
       MYSQL_PASSWORD: Inop2020
       SERVICE_TAGS: dev
       SERVICE_NAME: mysql


### PR DESCRIPTION
Dodałem plik docker-compose, który uruchamia api, frontend i baze jednocześnie. Do działania poza samym Dockerem potrzebny jest jeszcze Docker Compose (https://docs.docker.com/compose/install/).

Jak z tym działać.
1. Musi być taka struktura katalogów:
- api
   - ...
   - **docker-compose.yml**
- frontend
  - ...
2. Aby uruchomić całe środowisko to **z katalogu api** wykonujemy polecenie:
     - `docker-compose build` - aby zbudować
     - `docker-compose up` - aby wystartować
     - `docker-compose up -d` - aby wystartować niezależnie od terminala (-d)
     - `docker-compose down` - aby zatrzymać i usunąć kontenery i sieć (volumen, dane z bazy **nie zostaną usunięte**)
     - `docker-compose start/stop`
